### PR TITLE
Bugfix:SNSコメントへのnull表示抑止

### DIFF
--- a/pages/playing-logs/_id/index.vue
+++ b/pages/playing-logs/_id/index.vue
@@ -93,8 +93,8 @@ export default class Index extends Vue {
     const playInfo = this.$options.filters!.displayPlayInfo(this.playingLog);
     const composerName = this.playingLog.tune.composer.displayName;
     const tuneTitle = this.playingLog.tune.title;
-    // playingLog.position が null のときは空文字を入れて null が表示されるのを避ける
-    const position = `${this.playingLog.instrument.shortName}` + `${this.playingLog.position || ''}`;
+    // playingLog.position が null のときは空文字列を入れてshareTextのコメントに出てくるのを防ぐ
+    const position = `${this.playingLog.instrument.shortName}${this.playingLog.position || ''}`;
     return `${nickname}さんの${playInfo}された、${composerName}作曲${tuneTitle}の${position}での演奏記録`;
   }
 }

--- a/pages/playing-logs/_id/index.vue
+++ b/pages/playing-logs/_id/index.vue
@@ -93,7 +93,8 @@ export default class Index extends Vue {
     const playInfo = this.$options.filters!.displayPlayInfo(this.playingLog);
     const composerName = this.playingLog.tune.composer.displayName;
     const tuneTitle = this.playingLog.tune.title;
-    const position = `${this.playingLog.instrument.shortName}${this.playingLog.position}`;
+    // playingLog.position が null のときは空文字を入れて null が表示されるのを避ける
+    const position = `${this.playingLog.instrument.shortName}` + `${this.playingLog.position || ''}`;
     return `${nickname}さんの${playInfo}された、${composerName}作曲${tuneTitle}の${position}での演奏記録`;
   }
 }


### PR DESCRIPTION
演奏記録から SNS へのシェアボタンを押したときにコメントに null 表示がされる場合があったのを抑止