### PR TITLE
https://musig.net/composers/ページの作曲家リンク先を正しい URL に修正

### DIFF
--- a/pages/composers/index.vue
+++ b/pages/composers/index.vue
@@ -6,7 +6,7 @@
       </h1>
       <p v-for="composer in composers" :key="composer.id">
         <!-- TODO URL は id ではなく作曲家コードとか作れればそっちにする なければ id -->
-        <nuxt-link :to="`composers/${composer.id}`">{{ composer.displayName }} の演奏記録</nuxt-link>
+        <nuxt-link :to="`/composers/${composer.id}`">{{ composer.displayName }} の演奏記録</nuxt-link>
       </p>
     </div>
   </section>


### PR DESCRIPTION
絶対パス版です(backtick使用)
:to="`/composers/${composer.id}`"